### PR TITLE
Streamline Riemann solvers description

### DIFF
--- a/numerics_paper/version2/numerical_chj.tex
+++ b/numerics_paper/version2/numerical_chj.tex
@@ -581,8 +581,34 @@ In the numerical experiments in \S\ref{sec:num}, we obtain second-order experime
 order of convergence (EOC) for problems with smooth solution, which is expected since
 $\theta_{i\pm 1/2}\approx 0$ in smooth regions.
 Similarly, if $\theta_{i\pm 1/2}=1$, we recover the Lax-Wendroff method based on Rusanov's Riemann solver,
-which is clear by writing the fluctuations in Rusanov's method in terms of Roe's waves and speeds;
-see \eqref{fluct_rus}.
+which can be seen by writing the fluctuations in Rusanov's method in terms of Roe's waves and speeds.
+
+To see this, first consider \eqref{rus_cons} and rewrite the right-going fluctuation as follows:
+\begin{align}\label{rus_rs_aux}
+  \A^{+,\Rus}\Delta Q_{i-1/2}:=\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
+  = \bff(\bfu_{i})-\bff(\bfu_{i-1}) + \lambda_{i-1/2}^{\max}\left(\W_{i-1/2}^{1,\Rus}+\W_{i-1/2}^{2,\Rus}\right)
+  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus}.
+  %\A^{+,\Rus}\Delta Q_{i-1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
+\end{align}
+From \eqref{system_for_alphas} and \eqref{rusanov_waves} we get
+$\W^{1,\Rus}_{i-1/2}+\W^{2,\Rus}_{i-1/2}=\bfu_i-\bfu_{i-1}=\sum_p\W_{i-1/2}^p$.
+Using \eqref{cons_roe}, \eqref{rus_rs_aux} becomes
+\begin{align*}
+  \lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
+  = \sum_p \left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
+  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus},
+\end{align*}
+which implies that
+\begin{subequations}\label{fluct_rus}
+\begin{align}
+  \A^{+,\Rus}\Delta Q_{i-1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p,
+\end{align}
+and similarly,
+\begin{align}
+  \A^{-,\Rus}\Delta Q_{i+1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i+1/2}^p - \lambda_{i+1/2}^{\max}\right)\W_{i+1/2}^p.
+\end{align}
+\end{subequations}
+
 
 \subsection{Entropy-stable Riemann solver}\label{sec:entropy_stable}
 The Riemann solver presented in the previous section blends the solvers of Rusanov and Roe based on a

--- a/numerics_paper/version2/numerical_chj.tex
+++ b/numerics_paper/version2/numerical_chj.tex
@@ -260,6 +260,7 @@ solvers in the context of a 1-dimensional mesh.
 In the numerical experiments in \S\ref{sec:num} we use second-order Strang
 splitting \cite{strang1968construction} to extend the method to multiple dimensions.
 
+\subsection{Wave propagation methods}\label{sec:waveprop}
 The numerical solution $u_i$
 represents the average value over cell $i$, which extends from $x_\imh$ to $x_\iph$.
 At each time step and at each interface $x_\imh$, we approximately solve the
@@ -305,7 +306,11 @@ also suppress related real instabilities, while Roe's solver exhibits carbuncles
 Later we will combine these two solvers in order to better deal with shock instability.
 We refer to \cite{ketcheson2020riemann} and references therein for
 a full and detailed description of these two Riemann solvers in the context of
-the shallow water equations.
+the shallow water equations.  Both of these solvers satisfy the conservation
+property
+\begin{align} \label{rs_conservation}
+    \amdq_\imh + \apdq_\imh = \bff(\bfu_i) - \bff(\bfu_{i-1}).
+\end{align}
 
 
 \subsection{Rusanov's Riemann solver}\label{sec:rusanov}
@@ -413,7 +418,7 @@ via dissipation of entropy.
 %\end{align}
 %From \eqref{system_for_alphas} and \eqref{rusanov_waves} we get
 %$\W^{1,\Rus}_{i-1/2}+\W^{2,\Rus}_{i-1/2}=\bfu_i-\bfu_{i-1}=\sum_p\W_{i-1/2}^p$.
-%Using \eqref{cons_roe}, \eqref{rus_rs_aux} becomes
+%Using \eqref{rs_conservation}, \eqref{rus_rs_aux} becomes
 %\begin{align*}
 %  \lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
 %  = \sum_p \left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
@@ -592,7 +597,7 @@ To see this, first consider \eqref{rus_cons} and rewrite the right-going fluctua
 \end{align}
 From \eqref{system_for_alphas} and \eqref{rusanov_waves} we get
 $\W^{1,\Rus}_{i-1/2}+\W^{2,\Rus}_{i-1/2}=\bfu_i-\bfu_{i-1}=\sum_p\W_{i-1/2}^p$.
-Using \eqref{cons_roe}, \eqref{rus_rs_aux} becomes
+Using \eqref{rs_conservation}, \eqref{rus_rs_aux} becomes
 \begin{align*}
   \lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
   = \sum_p \left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
@@ -691,7 +696,7 @@ In terms of fluctuations, the entropy stability condition \eqref{es_cond} can be
 In this section we present one- and two-dimensional numerical experiments to demonstrate the behavior of the
 blended Riemann solver from \S\ref{sec:blended_rs} with the extra entropy dissipation from \S\ref{sec:entropy_stable}.
 We compare the behavior of the blended solver against the standard Roe's and Rusanov's solvers.
-In most of the experiments we use these Riemann solvers with the LWL method reviewed in \S\ref{sec:lax-wendroff-leveque}.
+In most of the experiments we use these Riemann solvers with the LWL method reviewed in \S\ref{sec:waveprop}.
 When the exact solution is available, we report a convergence test based on the $L^1$-error for the water height
 \begin{align*}
   E_1=\sum_i|K_i|~|h_i-h^e(\bfx_i)|,

--- a/numerics_paper/version2/numerical_chj.tex
+++ b/numerics_paper/version2/numerical_chj.tex
@@ -25,6 +25,7 @@
 \newcommand{\A}{{\mathcal A}}
 \newcommand{\apdq}{\A^+ \!\!{\Delta} Q}
 \newcommand{\amdq}{\A^- \!\!{\Delta} Q}
+\newcommand{\Ft}{\tilde{F}}
 \newcommand{\imh}{{i-1/2}}
 \newcommand{\iph}{{i+1/2}}
 \newcommand{\bff}{{\bf f}}
@@ -253,171 +254,95 @@ of CHJ stability.
 
 
 \section{Numerical methods}
-In this work, we consider Riemann-based finite volume methods.
-Considering a one dimensional hyperbolic conservation law,
-the cell average of the numerical solution given by a
-finite volume scheme (with forward Euler) can be written as follows:
-\begin{align}\label{first-order_FV}
-  \bfu_i^{n+1}=\bfu_i^n-\frac{\Delta t}{\Delta x}\left[\bfF_{i+1/2}-\bfF_{i-1/2}\right],
+In this work we study the behavior of certain shock-capturing finite volume
+methods based on the use of Riemann solvers.  For simplicity, we discuss these
+solvers in the context of a 1-dimensional mesh.  
+In the numerical experiments in \S\ref{sec:num} we use second-order Strang
+splitting \cite{strang1968construction} to extend the method to multiple dimensions.
+
+The numerical solution $u_i$
+represents the average value over cell $i$, which extends from $x_\imh$ to $x_\iph$.
+At each time step and at each interface $x_\imh$, we approximately solve the
+Riemann problem with initial states $(u^n_{i-1},u^n_i)$.  The approximate
+solution consists of a set of traveling discontinuities or waves $\W^p_\imh$
+and corresponding speeds $s^p_\imh$.
+We use the wave propagation framework developed by LeVeque \cite{leveque1997wave, leveque2002finite}
+and employed in the Clawpack software \cite{clawpack,pyclaw-sisc}, which implements the LWL scheme
+\begin{align}\label{second-order_via_fluct}
+  u_i^{n+1} = u_i^n-\frac{\Delta t}{\Delta x}\left[\apdq_\imh+\amdq_\iph\right]
+  -\frac{\Delta t}{\Delta x}\left[\tilde{F}_{i+1/2}-\tilde{F}_{i-1/2}\right],
 \end{align}
-where $\bfF_{i+1/2}=\bfF_{i+1/2}(u^n)$ is a numerical flux; i.e., $\bfF_{i+1/2}$ is
-a discretization of the flux $\bff(\bfu(x_{i+1/2},t^n))$.
-This numerical flux is composed of two parts, a consistent term that approximates
-the physical flux at the interface between cells $i$ and $i+1$, and a stabilization term.
-For instance, the well-known Rusanov's numerical flux is given by
-\begin{align}\label{rusanov_num_flux}
-  \bfF_{i+1/2}(\bfu)=\frac{\bff(\bfu_{i+1})+\bff(\bfu_i)}{2} - \lambda_{i+1/2}(\bfu_{i+1}-\bfu_i),
-\end{align}
-where $\lambda_{i+1/2}$ is an upper bound on the wave speed associated with the Riemann problem
-composed of the states $\bfu_i$ and $\bfu_{i+1}$.
-%If $z=u$ in \eqref{rusanov_num_flux}
-%; i.e., if the Rusanov's numerical flux is obtained considering
-%the cell averages of the solution
-%and if the time step is small enough,
-Method \eqref{first-order_FV} with Rusanov's flux \eqref{rusanov_num_flux}
-is positivity preserving and entropy stable; see for instance
-\cite{perthame1996positivity,tadmor2003entropy,guermond2016invariant}
-However, the accuracy of the numerical flux, and hence of the method, is
-limited to first order.
-Two alternatives are common to improve the accuracy properties of Rusanov's method.
-The numerical flux $\bfF_{i+1/2}$ can be approximated based on high-order polynomial
-reconstructions (or combinations of them) around the interface $i+1/2$.
-For smooth solutions, this strategy leads to arbitrarily high-order
-methods. Alternatively, second-order accuracy can be obtained by removing some of the
-numerical dissipation introduced by the stabilization component of the numerical flux.
-The second-order Lax-Wendroff method \cite{lax1959systems} is a popular example of this approach.
-In this work we consider an adaptation of Lax-Wendroff method,
-sometimes known as Lax-Wendroff-LeVeque (LWL) \cite{leveque1997wave,leveque2002finite},
-that incorporates limiters into the second-order correction.
-These high-order corrections to Rusanov's method require careful treatment to guarantee
-the solution is still positivity preserving and/or entropy stable.
-
-The accuracy of a given first- or second-order method depends heavily on the Riemann solver.
-In particular, Rusanov's Riemann solver is highly dissipative. In contrast, the well-known
-Roe's Riemann solver produces more accurate solutions.
-%
-As we discussed in the introduction, finite volume methods with
-Roe's Riemann solvers are prone to the carbuncle instability for the CHJ.
-In contrast, if we use Rusanov's
-Riemann solver, no carbuncles appear; however, many other important and physical features of
-the solution are dissipated, unless the grid is highly refined.
-Our main objective is to study the CHJ and to propose a Riemann solver
-that is carbuncle free but do not dissipate important features of the solution.
-To do that we propose a Riemann solver that blends Rusanov's and Roe's solvers.
-Our blending criterion is based on the residual of the entropy (in)equality,
-which induces dissipation of entropy near discontinuities.
-Blending these Riemann solvers has been proposed before
-to solve the Euler equations, see e.g.
-\cite{nishikawa2008very,wang2016developing,jaisankar2007diffusion,ohwada2018simple,deng2019new,ray2013entropy},
-the shallow water equations, see e.g. \cite{bader2014carbuncle,kemm2014note},
-and even the Navier-Stokes equations, see e.g. \cite{nishikawa2008very,ohwada2018simple}.
-In these references, the authors use blending criteria different than ours.
-Nevertheless, fixing the carbuncle instability by imposing entropy stability is not new.
-For example, in \cite{ismail2009affordable,ismail2009proposed},
-the authors developed carbuncle free solvers for the Euler equations
-via dissipation of entropy.
-
-\subsection{Lax-Wendroff-LeVeque method}\label{sec:lax-wendroff-leveque}
-Let us now review the second-order correction to method \eqref{first-order_FV} implemented in
-Clawpack \cite{clawpack} and PyClaw \cite{pyclaw-sisc}.
-We refer to \cite{leveque1997wave, leveque2002finite} for a detailed description of the method.
-We consider only a one-dimensional problem; in the
-numerical experiments in \S\ref{sec:num} we use second-order Strang's splitting \cite{strang1968construction}
-to extend the method to multiple dimensions.
-
-The finite volume method \eqref{first-order_FV} can be written in terms of right-
-and left-going waves emanating from the interfaces $i-1/2$ and $i+1/2$, respectively.
-The net contribution of these waves is called right- and left-going fluctuations.
 Upon defining $z^+:=\frac{1}{2}(z+|z|)$ and $z^-:=\frac{1}{2}(z-|z|)$,
 the fluctuations are given by
 \begin{align}\label{fluct}
-  %\A^+\Delta Q_{i-1/2} := \frac{1}{2}\sum_p\left(s_{i-1/2}^p+|s_{i-1/2}^p|\right)\W_{i-1/2}^p, \quad
-  %\A^-\Delta Q_{i+1/2} := \frac{1}{2}\sum_p\left(s_{i+1/2}^p-|s_{i+1/2}^p|\right)\W_{i+1/2}^p,
   \apdq_\imh := \sum_p\left(s_{i-1/2}^p\right)^+\W_{i-1/2}^p, \qquad
   \amdq_\iph := \sum_p\left(s_{i+1/2}^p\right)^-\W_{i+1/2}^p, \\
 \end{align}
-where $\W_{i\pm 1/2}^p$ and $s_{i\pm 1/2}^2$ are the waves and their corresponding speeds, respectively.
-The waves and their speed of propagation (to compute the fluctuations) are tightly related to Riemann solvers.
-In \S\ref{sec:riemann_solvers} we review the definition of the waves and speeds associated with
-Rusanov's and Roe's Riemann solvers.
-Based on fluctuations, method \eqref{first-order_FV} can be written as
+and represent the effect (to first
+order accuracy) of waves coming from the solution of the Riemann problem at
+each of the neighboring interfaces.  Meanwhile, $\Ft_{i\pm 1/2}$ are correction
+fluxes that make the method second-order accurate:
+\begin{align*}
+  \tilde{F}_{i\pm 1/2}=\frac{1}{2}\sum_p|s_{i\pm 1/2}^p|\left(1-\frac{\Delta t}{\Delta x}|s_{i\pm 1/2}^p|\right)\tilde\W_{i\pm 1/2}^p.
+\end{align*}
+Here $\tilde{\W}_{i\pm 1/2}^p$ is a TVD-limited version of $\W_{i\pm 1/2}^p$.
+We will sometimes work with
+the first-order method obtained by setting the correction fluxes to zero:
 \begin{align}\label{first-order_via_fluct}
-  u_i^{n+1}=u_i^n-\frac{\Delta t}{\Delta x}\left[\apdq_\imh+\amdq_\iph\right].
+  u_i^{n+1} = u_i^n-\frac{\Delta t}{\Delta x}\left[\apdq_\imh+\amdq_\iph\right]
 \end{align}
-
-The second-order LWL method removes some of the numerical dissipation in
-\eqref{first-order_via_fluct} via a flux correction at each interface. The method is written as follows:
-\begin{align}\label{second-order_via_fluct}
-  u_i^{n+1} = u_i^n-\frac{\Delta t}{\Delta x}\left[\A^+\Delta Q_{i-1/2}+\A^-\Delta Q_{i+1/2}\right]
-  -\frac{\Delta t}{\Delta x}\left[\tilde{F}_{i+1/2}-\tilde{F}_{i-1/2}\right],
+which, for the conservative Riemann solvers we use herein, can also be written
+as a first-order flux-differencing scheme:
+\begin{align}\label{first-order_FV}
+  \bfu_i^{n+1}=\bfu_i^n-\frac{\Delta t}{\Delta x}\left[\bfF_{i+1/2}-\bfF_{i-1/2}\right],
 \end{align}
-where
-\begin{align*}
-  \tilde{F}_{i\pm 1/2}=\frac{1}{2}\sum_p|s_{i\pm 1/2}^p|\left(1-\frac{\Delta t}{\Delta x}|s_{i\pm 1/2}^p|\right)\tilde\W_{i\pm 1/2}^p
-\end{align*}
-are the flux corrections at the interfaces $i\pm 1/2$. Here $\tilde{\W}_{i\pm 1/2}^p$ is a
-TVD-limited version of $\W_{i\pm 1/2}^p$.
-In this work, we consider the min-mod limiters, we refer to \cite{leveque1997wave} for more details.
-If no limiters are used
-($\tilde \W_{i\pm 1/2}^p = \W_{i\pm 1/2}^p$), \eqref{second-order_via_fluct} becomes
-the standard second-order Lax-Wendroff scheme, which in terms of fluctuation-like quantities
-is given by
-\begin{align*}
-  u_i^{n+1}=u_i^n-\frac{\Delta t}{\Delta x}
-\left[
-  \frac{1}{2}\left(s_{i-1/2}^p+\frac{\Delta t}{\Delta x}|s_{i-1/2}^p|^2\right)\W_{i-1/2}^p
-  +
-  \frac{1}{2}\left(s_{i+1/2}^p-\frac{\Delta t}{\Delta x}|s_{i+1/2}^p|^2\right)\W_{i+1/2}^p
-\right].
-\end{align*}
-To implement method \eqref{second-order_via_fluct},
-we need to choose a Riemann solver. Although the scheme is second-order
-regardless of the Riemann solver, the accuracy and robustness depends upon the
-Riemann solver. The approximate Riemann solver based on Rusanov's flux is robust and known to be carbuncle free.
-However, it adds large amounts of numerical diffusion that, for relatively coarse grids,
-might dissipate other physical and important features of the solution. If the approximate Riemann solver
-is based on Roe's average, the amount of numerical diffusion is highly reduced; however,
-such an approach is prone to develop the carbuncle instability for certain problems.
-Many carbuncle fixes to Roe's solver have been proposed for the Euler equations.
-In the context of the shallow water equations, we review in \S\ref{sec:riemann_solvers}
-the Riemann solver proposed in \cite{kemm2014note}.
+where $\bfF_{i+1/2}$ is a numerical approximation of the flux at $x_\iph$.
 
-\section{Riemann solvers}\label{sec:riemann_solvers}
-
-For the shallow water equations in two-dimensions, the structure of the exact (and some
-approximated) Riemann solvers contains three waves. This is the case, for example, of the well-known
-Roe's Riemann solver, see for instance \cite{roe1981approximate} and
-\cite[\S 15.3.3 and \S 21.7]{leveque2002finite}.
-Simpler approaches are also possible.
-For instance, methods \eqref{first-order_via_fluct} and \eqref{second-order_via_fluct}
-with Rusanov's numerical flux are based on only two waves that
-propagate with the same speed in opposite directions.
+Next we briefly review two commonly-used Riemann solvers: those of Rusanov and
+Roe.  Neither of these solvers deals with the carbuncle instability in fully
+satisfactory way.  Rusanov's solver suppresses the carbuncle but is known to
+also suppress related real instabilities, while Roe's solver exhibits carbuncles.
+Later we will combine these two solvers in order to better deal with shock instability.
 We refer to \cite{ketcheson2020riemann} and references therein for
-a full and detailed review of these two Riemann solvers.
+a full and detailed description of these two Riemann solvers in the context of
+the shallow water equations.
 
-\subsection{Roe's average}\label{sec:roe}
-The Roe's Riemann solver is based on evaluating the flux Jacobian using Roe's average
+
+\subsection{Rusanov's Riemann solver}\label{sec:rusanov}
+The Rusanov solver approximates the Riemann solution by with a single wave traveling in each
+direction.  Both waves are assumed to travel with speed $\lambda^{\max}_\imh$, which is an
+upper bound on the wave speeds appearing in the true solution of the Riemann problem.
+In this work, we take $\lambda_{i-1/2}^{\max}$ to be the upper bound
+from \cite[Prop. 3.7]{azerad2017well}.
+The waves are then given by
+\begin{align}\label{rusanov_waves}
+  \W_{i-1/2}^{1,\Rus}=\bfu_{i-1/2}-\bfu_{i-1}, \qquad
+  \W_{i-1/2}^{2,\Rus}=\bfu_{i}-\bfu_{i-1/2},
+\end{align}
+where the intermediate state $\bfu_{i-1/2}$ is determined by imposing conservation:
+\begin{align}\label{rus_cons}
+  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{1,\Rus}+\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus} = \bff(\bfu_{i})-\bff(\bfu_{i-1}).
+\end{align}
+The fluctuations are given by \eqref{fluct} with $s_{i-1/2}^1=-\lambda_{i-1/2}^{\max}$
+and $s_{i-1/2}^2=\lambda_{i-1/2}^{\max}$, and the first- and second-order methods based
+on Rusanov's solver are given by \eqref{first-order_via_fluct} and \eqref{second-order_via_fluct}, respectively.
+
+
+\subsection{Roe's Riemann solver} \label{sec:roe}
+The Roe Riemann solver is based on evaluating the flux Jacobian using Roe's average
 \begin{align}\label{roe_average}
   \bar h_{i-1/2}=\frac{1}{2}(h_{i-1}+h_i), \qquad
   \hat u_{i-1/2}=\frac{\sqrt{h_{i-1}}u_{i-1}+\sqrt{h_i}u_i}{\sqrt{h_{i-1}}+\sqrt{h_i}}, \qquad
   \hat v_{i-1/2}=\frac{\sqrt{h_{i-1}}v_{i-1}+\sqrt{h_i}v_i}{\sqrt{h_{i-1}}+\sqrt{h_i}}.
 \end{align}
-Let
+The waves and speeds are given by the eigenvectors and eigenvalues of the approximate
+flux Jacobian obtained using these averages, resulting in
 \begin{align*}
-\hat A_{i-1/2} =
-\begin{bmatrix}
-  0 & 1 & 0 \\
-  -\hat u_{i-1/2}^2+g\bar h_{i-1/2} & 2\hat u_{i-1/2} & 0 \\
-  -\hat u_{i-1/2} \hat v_{i-1/2} & \hat v_{i-1/2} & \hat u_{i-1/2}
-\end{bmatrix}
+  \hat\lambda_{i-1/2}^1=\hat u_{i-1/2}-g\sqrt{g\bar h_{i-1/2}}, \qquad
+  \hat\lambda_{i-1/2}^2=\hat u_{i-1/2}, \qquad
+  \hat\lambda_{i-1/2}^3=\hat u_{i-1/2}+g\sqrt{g\bar h_{i-1/2}}. \\
 \end{align*}
-be the flux Jacobian evaluated using Roe's average at the interface $i-1/2$.
-The average \eqref{roe_average} is designed to guarantee:
-i)  consistency of the approximate flux Jacobian
-($\hat A_{i-1/2}\rightarrow \bff^\prime(\bfu(x_{i-1/2}))$ as $\bfu_i, \bfu_{i-1}\rightarrow \bfu(x_{i-1/2})$);
-ii) hyperbolicity ($\hat A_{i-1/2}$ is diagonalizable with real eigenvalues);
-and iii) conservation ($\hat A_{i-1/2}(\bfu_i-\bfu_{i-1})=\bff(\bfu_i)-\bff(\bfu_{i-1})$).
-Let
+and $\W_{i-1/2}^p=\alpha_{i-1/2}^p\hat r_{i-1/2}^p$, with
 \begin{align*}
   \hat \bfr^1_{i-1/2} =
   \begin{bmatrix}
@@ -440,9 +365,7 @@ Let
     \hat v_{i-1/2}
   \end{bmatrix}
 \end{align*}
-be the eigenvectors of $\hat A_{i-1/2}$.
-The waves for the two-dimensional Riemann solver based on Roe's average are
-$\W_{i-1/2}^p=\alpha_{i-1/2}^p\hat r_{i-1/2}^p$, with $p=1,2,3$. Here $\alpha_{i-1/2}^p$ is given by
+and the factors $\alpha^p_\imh$ obtained by solving
 \begin{align}\label{system_for_alphas}
   \left[\hat \bfr^1_{i-1/2} ~\hat \bfr^2_{i-1/2} ~\hat \bfr^3_{i-1/2}\right]
   \begin{bmatrix}
@@ -452,128 +375,96 @@ $\W_{i-1/2}^p=\alpha_{i-1/2}^p\hat r_{i-1/2}^p$, with $p=1,2,3$. Here $\alpha_{i
   \end{bmatrix}
   =\Delta Q_{i-1/2}:=\bfu_i-\bfu_{i-1}.
 \end{align}
-%where $\alpha_{i-1/2}^p$ is the $p$-th entry from the solution of
+
+
+
+\section{An entropy-based blending of Rusanov and Roe}
+
+As we discussed in the introduction, finite volume methods with
+Roe's Riemann solvers are prone to the carbuncle instability for the CHJ.
+In contrast, if we use Rusanov's
+Riemann solver, no carbuncles appear; however, many other important and physical features of
+the solution are dissipated, unless the grid is highly refined.
+Our main objective is to study the CHJ and to propose a Riemann solver
+that is carbuncle-free but does not dissipate important features of the solution.
+To do that we propose a Riemann solver that blends Rusanov's and Roe's solvers.
+Our blending criterion is based on the residual of the entropy (in)equality,
+which induces dissipation of entropy near discontinuities.
+Blending these Riemann solvers has been proposed before
+to solve the Euler equations, see e.g.
+\cite{nishikawa2008very,wang2016developing,jaisankar2007diffusion,ohwada2018simple,deng2019new,ray2013entropy},
+the shallow water equations, see e.g. \cite{bader2014carbuncle,kemm2014note},
+and even the Navier-Stokes equations, see e.g. \cite{nishikawa2008very,ohwada2018simple}.
+In these references, the authors use blending criteria different than ours.
+Nevertheless, fixing the carbuncle instability by imposing entropy stability is not new.
+For example, in \cite{ismail2009affordable,ismail2009proposed},
+the authors developed carbuncle free solvers for the Euler equations
+via dissipation of entropy.
+
+
+%We close this section by remarking that the fluctuations associated with Rusanov's solver
+%can be expressed in terms of waves and speeds from Roe's solver. To see this, first consider \eqref{rus_cons}
+%and rewrite the right-going fluctuation as follows:
+%\begin{align}\label{rus_rs_aux}
+%  \A^{+,\Rus}\Delta Q_{i-1/2}:=\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
+%  = \bff(\bfu_{i})-\bff(\bfu_{i-1}) + \lambda_{i-1/2}^{\max}\left(\W_{i-1/2}^{1,\Rus}+\W_{i-1/2}^{2,\Rus}\right)
+%  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus}.
+%  %\A^{+,\Rus}\Delta Q_{i-1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
+%\end{align}
+%From \eqref{system_for_alphas} and \eqref{rusanov_waves} we get
+%$\W^{1,\Rus}_{i-1/2}+\W^{2,\Rus}_{i-1/2}=\bfu_i-\bfu_{i-1}=\sum_p\W_{i-1/2}^p$.
+%Using \eqref{cons_roe}, \eqref{rus_rs_aux} becomes
+%\begin{align*}
+%  \lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
+%  = \sum_p \left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
+%  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus},
 %\end{align*}
-The speed of the waves is given by the eigenvalues of $\hat A_{i-1/2}$
-\begin{align*}
-  \hat\lambda_{i-1/2}^1=\hat u_{i-1/2}-g\sqrt{g\bar h_{i-1/2}}, \qquad
-  \hat\lambda_{i-1/2}^2=\hat u_{i-1/2}, \qquad
-  \hat\lambda_{i-1/2}^3=\hat u_{i-1/2}+g\sqrt{g\bar h_{i-1/2}}. \\
-\end{align*}
+%which implies that
+%\begin{subequations}\label{fluct_rus}
+%\begin{align}
+%  \A^{+,\Rus}\Delta Q_{i-1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p,
+%\end{align}
+%and similarly,
+%\begin{align}
+%  \A^{-,\Rus}\Delta Q_{i+1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i+1/2}^p - \lambda_{i+1/2}^{\max}\right)\W_{i+1/2}^p.
+%\end{align}
+%\end{subequations}
 
-The waves and speeds at interface $i+1/2$ are computed similarly.
-The fluctuations are given by \eqref{fluct} with $s_{i\pm 1/2}^p=\hat\lambda_{i\pm 1/2}^p$
-Finally, the first- and second-order methods based on Roe's Riemann solver are given by
-\eqref{first-order_via_fluct} and \eqref{second-order_via_fluct}, respectively.
-We close this review by remarking that the conservation property
-$\hat A_{i-1/2}(\bfu_i-\bfu_{i-1})=\bff(\bfu_i)-\bff(\bfu_{i-1})$ implies that
-\begin{align}\label{cons_roe}
-  \A^-\Delta Q_{i-1/2}+\A^+\Delta Q_{i-1/2}=\sum_p \hat\lambda_{i-1/2}^p\W_{i-1/2}^p=\bff(\bfu_{i})-\bff(\bfu_{i-1}),
-\end{align}
-a property we will use in the next section.
+%\subsubsection{HLLEMCC solver}
+%The HLLEMCC approximate Riemann solver for the shallow water equations was proposed
+%in \cite{kemm2014note} specifically to deal with carbuncles.  The idea is to adjust
+%the amount of dissipation applied to the shear wave, adding dissipation in regions
+%where unphysical carbuncles would appear.  The approximate solution in this
+%case consists of four waves; the faster waves use the HLLE wave speeds and carry
+%jumps only in the depth and normal momentum, while the slower waves carry jumps
+%only in the transverse momentum.  By adjusting the value of $\phi$, this solver
+%can behave like the HLLE solver (if $\phi=1$) or like the Roe solver (if $\phi=0$).
+%
+%The middle states $q^1_m, q^2_m$ are the same as those used for the HLLE solver.
+%Requiring conservation of the transverse momentum gives
+%\begin{align*}
+%  q^3_m = \frac{f^3_l - f^3_r - (\hat{v}-\phi\hat{c})q^3_l + (\hat{v}+\phi\hat{c})q^3_r}{2\phi\hat{c}}.
+%\end{align*}
+%Here $\hat{v}, \hat{c}$ are the Roe-average normal velocity and sound speed, respectively, whereas the function $\phi$ is given by
+%\begin{equation}\label{if}
+%\phi(\theta)=\min\left\lbrace 1,\, \left(\varepsilon\,\theta\,\max\left\lbrace0,\,1-Fr_{u}^{\alpha} \right\rbrace \right)   \right\rbrace^{\beta}
+%\end{equation}
+%where $Fr_{u}$ is the Froude number perpendicular to the cell face and $\varepsilon$, $\alpha$, and $\beta$ are parameters that have to be chosen appropriately. For the shallow water equations, authors in \cite{kemm2014note} propose to use $\varepsilon=10^{-3}$ and $\alpha=\beta=\frac{1}{3}$. The value of $\theta$ is calculated as the 2-norm of the residual in the Rankine-Hugoniot condition for the shear wave.
+%
+%The HLLEMCC solver follows the ideas of the Harten-Hyman entropy fix by splitting the shear wave with speed $\hat{u}$, into two waves moving with speeds $\hat{u}-\phi\hat{c}$ and $\hat{u}+\phi\hat{c}$ (see figure \ref{HLLEMCC}). Its implementation, in terms of the fluctuations, is performed by using the values $\hat{u}^{\pm}$ calculated with an absolute-value function defined as
+%
+%\begin{align*}
+%\varphi(\lambda)=\frac{\vert \lambda-\phi(\theta)\hat{c}\,\vert+\vert \lambda+\phi(\theta)\hat{c}\,\vert}{2}
+%\end{align*}
+%
+%\begin{figure}
+%    \center
+%    \includegraphics[width=0.6\textwidth]{figures/hllemcc.pdf}
+%    \caption{Structure of the HLLEMCC approximate Riemann solution, with four waves.}
+%    \label{HLLEMCC}
+%\end{figure}
 
-\subsection{Rusanov's Riemann solver}\label{sec:rusanov}
-The Rusanov's Riemann solver considers only two waves that emanate from each interface,
-say for instance interface $i-1/2$, and travel with the same speed $\lambda_{i-1/2}^{\max}\geq 0$
-but in opposite directions.
-The speed of propagation $\lambda_{i-1/2}^{\max}$ is an upper bound on the maximum wave speed
-associated with the corresponding Riemann problem between the states $\bfu_{i-1}$ and $\bfu_{i}$.
-In this work, we define $\lambda_{i-1/2}^{\max}$ via the guaranteed upper bound from \cite[Prop. 3.7]{azerad2017well}.
-The waves are given by
-\begin{align}\label{rusanov_waves}
-  \W_{i-1/2}^{1,\Rus}=\bfu_{i-1/2}-\bfu_{i-1}, \qquad
-  \W_{i-1/2}^{2,\Rus}=\bfu_{i}-\bfu_{i-1/2},
-\end{align}
-where $\bfu_{i-1/2}$ is a middle state in the solution of the Riemann problem. The middle state is obtained
-by imposing
-\begin{align}\label{rus_cons}
-  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{1,\Rus}+\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus} = \bff(\bfu_{i})-\bff(\bfu_{i-1}),
-\end{align}
-which guarantees the solver is conservative.
-The fluctuations are given by \eqref{fluct} with $s_{i-1/2}^1=-\lambda_{i-1/2}^{\max}$
-and $s_{i-1/2}^2=\lambda_{i-1/2}^{\max}$, and the first- and second-order methods based
-on Rusanov's solver are given by \eqref{first-order_via_fluct} and \eqref{second-order_via_fluct}, respectively.
-
-We close this section by remarking that the fluctuations associated with Rusanov's solver
-can be expressed in terms of waves and speeds from Roe's solver. To see this, first consider \eqref{rus_cons}
-and rewrite the right-going fluctuation as follows:
-\begin{align}\label{rus_rs_aux}
-  \A^{+,\Rus}\Delta Q_{i-1/2}:=\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
-  = \bff(\bfu_{i})-\bff(\bfu_{i-1}) + \lambda_{i-1/2}^{\max}\left(\W_{i-1/2}^{1,\Rus}+\W_{i-1/2}^{2,\Rus}\right)
-  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus}.
-  %\A^{+,\Rus}\Delta Q_{i-1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
-\end{align}
-From \eqref{system_for_alphas} and \eqref{rusanov_waves} we get
-$\W^{1,\Rus}_{i-1/2}+\W^{2,\Rus}_{i-1/2}=\bfu_i-\bfu_{i-1}=\sum_p\W_{i-1/2}^p$.
-Using \eqref{cons_roe}, \eqref{rus_rs_aux} becomes
-\begin{align*}
-  \lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\max}
-  = \sum_p \left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p
-  -\lambda_{i-1/2}^{\max}\W_{i-1/2}^{2,\Rus},
-\end{align*}
-which implies that
-\begin{subequations}\label{fluct_rus}
-\begin{align}
-  \A^{+,\Rus}\Delta Q_{i-1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i-1/2}^p + \lambda_{i-1/2}^{\max}\right)\W_{i-1/2}^p,
-\end{align}
-and similarly,
-\begin{align}
-  \A^{-,\Rus}\Delta Q_{i+1/2}=\frac{1}{2}\sum_p\left(\hat \lambda_{i+1/2}^p - \lambda_{i+1/2}^{\max}\right)\W_{i+1/2}^p.
-\end{align}
-\end{subequations}
-
-\subsubsection{HLLEMCC solver}
-The HLLEMCC approximate Riemann solver for the shallow water equations was proposed
-in \cite{kemm2014note} specifically to deal with carbuncles.  The idea is to adjust
-the amount of dissipation applied to the shear wave, adding dissipation in regions
-where unphysical carbuncles would appear.  The approximate solution in this
-case consists of four waves; the faster waves use the HLLE wave speeds and carry
-jumps only in the depth and normal momentum, while the slower waves carry jumps
-only in the transverse momentum.  By adjusting the value of $\phi$, this solver
-can behave like the HLLE solver (if $\phi=1$) or like the Roe solver (if $\phi=0$).
-
-The middle states $q^1_m, q^2_m$ are the same as those used for the HLLE solver.
-Requiring conservation of the transverse momentum gives
-\begin{align*}
-  q^3_m = \frac{f^3_l - f^3_r - (\hat{v}-\phi\hat{c})q^3_l + (\hat{v}+\phi\hat{c})q^3_r}{2\phi\hat{c}}.
-\end{align*}
-Here $\hat{v}, \hat{c}$ are the Roe-average normal velocity and sound speed, respectively, whereas the function $\phi$ is given by
-\begin{equation}\label{if}
-\phi(\theta)=\min\left\lbrace 1,\, \left(\varepsilon\,\theta\,\max\left\lbrace0,\,1-Fr_{u}^{\alpha} \right\rbrace \right)   \right\rbrace^{\beta}
-\end{equation}
-where $Fr_{u}$ is the Froude number perpendicular to the cell face and $\varepsilon$, $\alpha$, and $\beta$ are parameters that have to be chosen appropriately. For the shallow water equations, authors in \cite{kemm2014note} propose to use $\varepsilon=10^{-3}$ and $\alpha=\beta=\frac{1}{3}$. The value of $\theta$ is calculated as the 2-norm of the residual in the Rankine-Hugoniot condition for the shear wave.
-
-The HLLEMCC solver follows the ideas of the Harten-Hyman entropy fix by splitting the shear wave with speed $\hat{u}$, into two waves moving with speeds $\hat{u}-\phi\hat{c}$ and $\hat{u}+\phi\hat{c}$ (see figure \ref{HLLEMCC}). Its implementation, in terms of the fluctuations, is performed by using the values $\hat{u}^{\pm}$ calculated with an absolute-value function defined as
-
-\begin{align*}
-\varphi(\lambda)=\frac{\vert \lambda-\phi(\theta)\hat{c}\,\vert+\vert \lambda+\phi(\theta)\hat{c}\,\vert}{2}
-\end{align*}
-
-\begin{figure}
-    \center
-    \includegraphics[width=0.6\textwidth]{figures/hllemcc.pdf}
-    \caption{Structure of the HLLEMCC approximate Riemann solution, with four waves.}
-    \label{HLLEMCC}
-\end{figure}
-
-\section{Entropy-dissipative Riemann solver}\label{sec:ent_diss_rs}
-Consider a hyperbolic system of conservation laws
-\begin{align}\label{cons_law}
-  \frac{\partial \bfu(\bfx)}{\partial t} + \nabla\cdot \bff(\bfu(\bfx))=0, \quad \bfx\in\Omega,
-\end{align}
-with a en entropy pair $\left(\eta(\bfu), \bfq(\bfu)\right)$.
-A weak solution of \eqref{cons_law} is called an entropy solution if
-\begin{align}\label{ent_inequality}
-  \frac{\partial \eta(\bfu(\bfx))}{\partial t} + \nabla\cdot \bfq(\bfu(\bfx))\leq 0, \quad \bfx\in\Omega,
-\end{align}
-holds, in a distribution sense, for any entropy pair.
-It is desirable for a numerical method to satisfy a discrete version of the entropy inequality
-\eqref{ent_inequality}, but many widely-used discretizations do not.
-In this work, we propose an entropy stable approximate Riemann solver for the one dimensional
-shallow water equations. We use this Riemann solver as building block within the LWL
-method, as described in \cite{leveque1997wave,leveque2002finite} and implemented in Clawpack.
-
-\subsection{Entropy residual}
+\subsection{The entropy residual}
 Let $S_i$ be the set of cells containing cell $i$ and those that share a face with it.
 Also let $\bfv(\bfu)=\eta^\prime(\bfu)$ be the entropy variable.
 Based on \cite{guermond2011entropy}, we consider
@@ -582,7 +473,7 @@ Based on \cite{guermond2011entropy}, we consider
   =\int_{S_i} \left[\frac{\partial \eta(\bfu)}{\partial t} + \bfv(\bfu) \cdot \nabla\cdot \bff(\bfu)\right] d\bfx
 \end{align}
 as a measurement of the entropy production in $S_i$.
-To avoid approximating the time derivative of the entropy, we follow
+To avoid the need to compute the time derivative of the entropy, we follow
 \cite{guermond2018second, guermond2018well} and use
 $\int \frac{\partial\eta(\bfu)}{\partial t}d\bfx=-\int \nabla\cdot\bfq(\bfu) d\bfx$,
 which holds in smooth regions. Then we define
@@ -611,12 +502,12 @@ dimensions. In the next section, we use $\theta_i$ to blend Rusanov's and Roe's 
 
 \subsection{Blended Riemann solver}\label{sec:blended_rs}
 In this section, we use \eqref{Ri}, which is a normalized measurement of the entropy residual \eqref{ent_residual},
-to blend Rusanov's and Roe's Riemann solvers. To do this, we define the following numerical flux:
+to blend Rusanov's and Roe's Riemann solvers. To do this, we define the blended numerical flux:
 \begin{align}\label{num_flux_ev}
   F_{i+1/2} = \frac{\bff(\bfu_{i+1})+\bff(\bfu_i)}{2}
-  - \frac{1}{2} \left( \theta_{i+1/2}\lambda_{i+1/2}^{\max} I + (1-\theta_{i+1/2})|\hat A_{i+1/2}| \right)(\bfu_{i+1}-\bfu_{i}),
+  - \frac{1}{2} \left( \theta_{i+1/2}\lambda_{i+1/2}^{\max} I + (1-\theta_{i+1/2})|\hat A_{i+1/2}| \right)(\bfu_{i+1}-\bfu_{i}).
 \end{align}
-and similarly for $F_{i-1/2}$. Here $I\in\mathbb{R}^{3\times 3}$ is the identity matrix,
+Here $I\in\mathbb{R}^{3\times 3}$ is the identity matrix,
 $\theta_{i+1/2}=\max\{\theta_{i+1},\theta_i\}$, $\lambda_{i+1/2}^{\max}$ is the
 upper bound on the wave speed used in Rusanov's Riemann solver (see \S \ref{sec:rusanov}),
 and $\hat A_{i+1/2}$ is Roe's averaged flux Jacobian (see \S \ref{sec:roe}).


### PR DESCRIPTION
This PR reorganizes the material on Riemann solvers and removes a lot of the background material that I think readers can be expected to know or to obtain by reading other references.

- I also removed the HLLEMCC section; we will want to add back in a very brief description
- I still want to revise the section on the entropy residual, but I'm waiting until we decide whether we can stop integrating over neighboring cells, since that would simplify things further.